### PR TITLE
Add headless Selenium script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Web Page Scraper to GAS
+
+This repository contains a Python script that uses Selenium to scrape content from a web page and send it to a Google Apps Script (GAS) endpoint.
+
+## Requirements
+
+- Python 3.8+
+- Chromium and chromedriver (or Chrome and chromedriver) installed
+- `pip` for installing Python packages
+
+Install Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Set the GAS endpoint URL as an environment variable:
+
+```bash
+export GAS_URL="https://script.google.com/macros/s/EXAMPLE/exec"
+```
+
+Run the script with the target URL and a CSS selector for the element you wish to extract:
+
+```bash
+python web_to_gas.py "https://example.com" "h1"
+```
+
+The text from the selected element will be sent to the GAS endpoint as JSON.
+
+## Google Apps Script Example
+
+A minimal GAS script that accepts a POST request:
+
+```javascript
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+  // handle data.text as needed
+  return ContentService.createTextOutput('Received: ' + data.text);
+}
+```
+
+Save this as a Web App and use the deployed URL as `GAS_URL`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium
+requests

--- a/web_to_gas.py
+++ b/web_to_gas.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import requests
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
+GAS_URL = os.environ.get('GAS_URL')
+
+
+def extract_text(url: str, selector: str) -> str:
+    options = Options()
+    options.add_argument('--headless')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    driver = webdriver.Chrome(options=options)
+    try:
+        driver.get(url)
+        element = driver.find_element(By.CSS_SELECTOR, selector)
+        return element.text
+    finally:
+        driver.quit()
+
+
+def send_to_gas(text: str) -> requests.Response:
+    if not GAS_URL:
+        raise RuntimeError('GAS_URL environment variable not set')
+    return requests.post(GAS_URL, json={'text': text})
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Usage: python web_to_gas.py <url> <css_selector>')
+        sys.exit(1)
+    url = sys.argv[1]
+    selector = sys.argv[2]
+    text = extract_text(url, selector)
+    response = send_to_gas(text)
+    print('GAS response:', response.text)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python script to extract page content using Selenium and send to GAS
- document requirements and usage
- define dependencies

## Testing
- `pip install -r requirements.txt`
- `python web_to_gas.py https://example.com h1` *(fails: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68440810023083308243fd5350200171